### PR TITLE
correct ANSI codes for bold/italic on the terminal

### DIFF
--- a/esc-solarized.outlang
+++ b/esc-solarized.outlang
@@ -1,13 +1,12 @@
 extension "txt"
 
-styletemplate "[38;05;$stylem$text"
+styletemplate "\x1b[$stylem$text\x1b[m"
 styleseparator ";"
 
-# TODO: Make these work
 bold "01$style"
 underline "04$style"
-italics "$style"
-color "$style"
+italics "03$style"
+color "38;05;$style"
 
 colormap
 "yellow" "136"


### PR DESCRIPTION
cribbed from other `.outlang` files in the `source-highlight` package and https://misc.flogisoft.com/bash/tip_colors_and_formatting, these changes appear to get bold/italic working